### PR TITLE
Sample Usage of the UnitOfWork Pattern

### DIFF
--- a/Onion/sample/1.Core/MiniBlog.Core.RequestResponse/Blogs/Commands/AddBlogPost/AddBlogPostCommand.cs
+++ b/Onion/sample/1.Core/MiniBlog.Core.RequestResponse/Blogs/Commands/AddBlogPost/AddBlogPostCommand.cs
@@ -1,0 +1,14 @@
+﻿using Zamin.Core.RequestResponse.Commands;
+using Zamin.Core.RequestResponse.Endpoints;
+
+namespace MiniBlog.Core.RequestResponse.Blogs.Commands.AddBlogPost;
+
+public class AddBlogPostCommand : ICommand<Guid>, IWebRequest
+{
+    public string BlogTitle { get; set; } = string.Empty;
+    public string BlogDescription { get; set; } = string.Empty;
+    public string PostTitle { get; set; } = string.Empty;
+
+    public string Path => "/api/Blog/AddBlogPost";
+}
+

--- a/Onion/sample/1.Core/Miniblog.Core.ApplicationService/Blogs/Commands/AddBlogPost/AddBlogPostCommandHandler.cs
+++ b/Onion/sample/1.Core/Miniblog.Core.ApplicationService/Blogs/Commands/AddBlogPost/AddBlogPostCommandHandler.cs
@@ -1,0 +1,32 @@
+﻿using MiniBlog.Core.Contracts.Blogs.Commands;
+using MiniBlog.Core.Domain.Blogs.Entities;
+using MiniBlog.Core.RequestResponse.Blogs.Commands.AddBlogPost;
+using MiniBlog.Core.RequestResponse.Blogs.Commands.AddPost;
+using Zamin.Core.ApplicationServices.Commands;
+using Zamin.Core.Contracts.Data.Commands;
+using Zamin.Core.Domain.Exceptions;
+using Zamin.Core.RequestResponse.Commands;
+using Zamin.Utilities;
+
+namespace MiniBlog.Core.ApplicationService.Blogs.Commands.AddBlogPost;
+
+public sealed class AddBlogPostCommandHandler(ZaminServices zaminServices,
+                                 IBlogCommandRepository _blogCommandRepository,
+                                 IUnitOfWork _unitOfWork) : CommandHandler<AddBlogPostCommand, Guid>(zaminServices)
+{
+    public override async Task<CommandResult<Guid>> Handle(AddBlogPostCommand command)
+    {
+        _unitOfWork.BeginTransaction();
+
+        Blog blog = Blog.Create(command.BlogTitle, command.BlogDescription);
+        await _blogCommandRepository.InsertAsync(blog);
+        await _unitOfWork.CommitAsync();
+
+        blog.AddPost(command.PostTitle);
+        await _unitOfWork.CommitAsync();
+
+        _unitOfWork.CommitTransaction();
+
+        return Ok(blog.BusinessId.Value);
+    }
+}

--- a/Onion/sample/3.Endpoints/MiniBlog.Endpoints.API/Blogs/BlogController.cs
+++ b/Onion/sample/3.Endpoints/MiniBlog.Endpoints.API/Blogs/BlogController.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Mvc;
+using MiniBlog.Core.RequestResponse.Blogs.Commands.AddBlogPost;
 using MiniBlog.Core.RequestResponse.Blogs.Commands.AddPost;
 using MiniBlog.Core.RequestResponse.Blogs.Commands.Create;
 using MiniBlog.Core.RequestResponse.Blogs.Commands.Delete;
@@ -16,6 +17,10 @@ namespace MiniBlog.Endpoints.API.Blogs
         #region Commands
         [HttpPost("Create")]
         public async Task<IActionResult> CreateBlog([FromBody] CreateBlogCommand command) => await Create<CreateBlogCommand, Guid>(command);
+
+        [HttpPost("AddBlogPost")]
+        public async Task<IActionResult> AddBlogPost([FromBody] AddBlogPostCommand command) => await Create<AddBlogPostCommand, Guid>(command);
+
 
         [HttpPut("Update")]
         public async Task<IActionResult> UpdateBlog([FromBody] UpdateBlogCommand command) => await Edit(command);


### PR DESCRIPTION

I added a new service called AddBlogPostCommandHandler to the ApplicationService.Blogs.Commands namespace. This service demonstrates how to use the UnitOfWork pattern in the Zamin Framework.
In this example, I design an API that simultaneously creates a blog and an associated post. To ensure data consistency, both the blog and the post are saved within a single transaction, with the UnitOfWork pattern ensuring seamless transaction management.