### PR TITLE
Rename Async methods in BaseController

### DIFF
--- a/Onion/sample/3.Endpoints/MiniBlog.Endpoints.API/Blogs/BlogController.cs
+++ b/Onion/sample/3.Endpoints/MiniBlog.Endpoints.API/Blogs/BlogController.cs
@@ -15,27 +15,27 @@ namespace MiniBlog.Endpoints.API.Blogs
     {
         #region Commands
         [HttpPost("Create")]
-        public async Task<IActionResult> CreateBlog([FromBody] CreateBlogCommand command) => await Create<CreateBlogCommand, Guid>(command);
+        public async Task<IActionResult> CreateBlog([FromBody] CreateBlogCommand command) => await CreateAsync<CreateBlogCommand, Guid>(command);
 
         [HttpPut("Update")]
-        public async Task<IActionResult> UpdateBlog([FromBody] UpdateBlogCommand command) => await Edit(command);
+        public async Task<IActionResult> UpdateBlog([FromBody] UpdateBlogCommand command) => await EditAsync(command);
 
         [HttpDelete("Delete")]
-        public async Task<IActionResult> DeleteBlog([FromBody] DeleteBlogCommand command) => await Delete(command);
+        public async Task<IActionResult> DeleteBlog([FromBody] DeleteBlogCommand command) => await DeleteAsync(command);
 
         [HttpDelete("DeleteGraph")]
-        public async Task<IActionResult> DeleteGraphBlog([FromBody] DeleteGraphBlogCommand command) => await Delete(command);
+        public async Task<IActionResult> DeleteGraphBlog([FromBody] DeleteGraphBlogCommand command) => await DeleteAsync(command);
 
         [HttpPost("AddPost")]
-        public async Task<IActionResult> AddPost([FromBody] AddPostCommand command) => await Create(command);
+        public async Task<IActionResult> AddPost([FromBody] AddPostCommand command) => await CreateAsync(command);
 
         [HttpDelete("RemovePost")]
-        public async Task<IActionResult> RemovePost([FromBody] RemovePostCommand command) => await Delete(command);
+        public async Task<IActionResult> RemovePost([FromBody] RemovePostCommand command) => await DeleteAsync(command);
         #endregion
 
         #region Queries
         [HttpGet("GetById")]
-        public async Task<IActionResult> GetById(GetBlogByIdQuery query) => await Query<GetBlogByIdQuery, BlogQr?>(query);
+        public async Task<IActionResult> GetById(GetBlogByIdQuery query) => await QueryAsync<GetBlogByIdQuery, BlogQr?>(query);
         #endregion
 
         #region Methods

--- a/Onion/src/4.EndPoints/Zamin.EndPoints.Web/Controllers/BaseController.cs
+++ b/Onion/src/4.EndPoints/Zamin.EndPoints.Web/Controllers/BaseController.cs
@@ -4,130 +4,152 @@ using Zamin.Utilities;
 using Zamin.EndPoints.Web.Extensions;
 using Zamin.Extensions.Serializers.Abstractions;
 using Zamin.Core.Contracts.ApplicationServices.Events;
-using Zamin.Core.RequestResponse.Commands;
-using Zamin.Core.RequestResponse.Common;
-using Zamin.Core.RequestResponse.Queries;
 
-namespace Zamin.EndPoints.Web.Controllers
+namespace Zamin.EndPoints.Web.Controllers;
+
+public class BaseController : Controller
 {
-    public class BaseController : Controller
+    protected ICommandDispatcher CommandDispatcher => HttpContext.CommandDispatcher();
+    protected IQueryDispatcher QueryDispatcher => HttpContext.QueryDispatcher();
+    protected IEventDispatcher EventDispatcher => HttpContext.EventDispatcher();
+    protected ZaminServices ZaminApplicationContext => HttpContext.ZaminApplicationContext();
+
+    public IActionResult Excel<T>(List<T> list)
     {
-        protected ICommandDispatcher CommandDispatcher => HttpContext.CommandDispatcher();
-        protected IQueryDispatcher QueryDispatcher => HttpContext.QueryDispatcher();
-        protected IEventDispatcher EventDispatcher => HttpContext.EventDispatcher();
-        protected ZaminServices ZaminApplicationContext => HttpContext.ZaminApplicationContext();
+        var serializer = HttpContext.RequestServices.GetRequiredService<IExcelSerializer>();
+        var bytes = serializer.ListToExcelByteArray(list);
+        return File(bytes, "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
+    }
 
-        public IActionResult Excel<T>(List<T> list)
-        {
-            var serializer = (IExcelSerializer)HttpContext.RequestServices.GetRequiredService(typeof(IExcelSerializer));
-            var bytes = serializer.ListToExcelByteArray(list);
-            return File(bytes, "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
-        }
-        public IActionResult Excel<T>(List<T> list, string fileName)
-        {
-            var serializer = (IExcelSerializer)HttpContext.RequestServices.GetRequiredService(typeof(IExcelSerializer));
-            var bytes = serializer.ListToExcelByteArray(list);
-            return File(bytes, "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", $"{fileName}.xlsx");
-        }
+    public IActionResult Excel<T>(List<T> list, string fileName)
+    {
+        var serializer = HttpContext.RequestServices.GetRequiredService<IExcelSerializer>();
+        var bytes = serializer.ListToExcelByteArray(list);
+        return File(bytes, "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", $"{fileName}.xlsx");
+    }
 
+    [Obsolete("This method is deprecated. Use CreateAsync instead.")]
+    protected Task<IActionResult> Create<TCommand, TCommandResult>(TCommand command)
+        where TCommand : class, ICommand<TCommandResult>
+        => CreateAsync<TCommand, TCommandResult>(command);
 
-        protected async Task<IActionResult> Create<TCommand, TCommandResult>(TCommand command) where TCommand : class, ICommand<TCommandResult>
-        {
-            var result = await CommandDispatcher.Send<TCommand, TCommandResult>(command);
-            if (result.Status == ApplicationServiceStatus.Ok)
-            {
-                return StatusCode((int)HttpStatusCode.Created, result.Data);
-            }
+    protected async Task<IActionResult> CreateAsync<TCommand, TCommandResult>(TCommand command)
+        where TCommand : class, ICommand<TCommandResult>
+    {
+        var result = await CommandDispatcher.Send<TCommand, TCommandResult>(command);
+        if (result.Status is ApplicationServiceStatus.Ok)
+            return StatusCode((int)HttpStatusCode.Created, result.Data);
+
+        return BadRequest(result.Messages);
+    }
+
+    [Obsolete("This method is deprecated. Use CreateAsync instead.")]
+    protected Task<IActionResult> Create<TCommand>(TCommand command)
+        where TCommand : class, ICommand
+        => CreateAsync<TCommand>(command);
+
+    protected async Task<IActionResult> CreateAsync<TCommand>(TCommand command)
+        where TCommand : class, ICommand
+    {
+        var result = await CommandDispatcher.Send(command);
+        if (result.Status is ApplicationServiceStatus.Ok)
+            return StatusCode((int)HttpStatusCode.Created);
+
+        return BadRequest(result.Messages);
+    }
+
+    [Obsolete("This method is deprecated. Use EditAsync instead.")]
+    protected Task<IActionResult> Edit<TCommand, TCommandResult>(TCommand command)
+        where TCommand : class, ICommand<TCommandResult>
+        => EditAsync<TCommand, TCommandResult>(command);
+
+    protected async Task<IActionResult> EditAsync<TCommand, TCommandResult>(TCommand command)
+        where TCommand : class, ICommand<TCommandResult>
+    {
+        var result = await CommandDispatcher.Send<TCommand, TCommandResult>(command);
+        if (result.Status is ApplicationServiceStatus.Ok)
+            return StatusCode((int)HttpStatusCode.OK, result.Data);
+
+        if (result.Status is ApplicationServiceStatus.NotFound)
+            return StatusCode((int)HttpStatusCode.NotFound, command);
+
+        return BadRequest(result.Messages);
+    }
+
+    [Obsolete("This method is deprecated. Use EditAsync instead.")]
+    protected Task<IActionResult> Edit<TCommand>(TCommand command)
+        where TCommand : class, ICommand
+        => EditAsync<TCommand>(command);
+
+    protected async Task<IActionResult> EditAsync<TCommand>(TCommand command)
+        where TCommand : class, ICommand
+    {
+        var result = await CommandDispatcher.Send(command);
+        if (result.Status is ApplicationServiceStatus.Ok)
+            return StatusCode((int)HttpStatusCode.OK);
+
+        if (result.Status is ApplicationServiceStatus.NotFound)
+            return StatusCode((int)HttpStatusCode.NotFound, command);
+
+        return BadRequest(result.Messages);
+    }
+
+    [Obsolete("This method is deprecated. Use DeleteAsync instead.")]
+    protected Task<IActionResult> Delete<TCommand, TCommandResult>(TCommand command)
+        where TCommand : class, ICommand<TCommandResult>
+        => DeleteAsync<TCommand, TCommandResult>(command);
+
+    protected async Task<IActionResult> DeleteAsync<TCommand, TCommandResult>(TCommand command)
+        where TCommand : class, ICommand<TCommandResult>
+    {
+        var result = await CommandDispatcher.Send<TCommand, TCommandResult>(command);
+        if (result.Status is ApplicationServiceStatus.Ok)
+            return StatusCode((int)HttpStatusCode.OK, result.Data);
+
+        if (result.Status is ApplicationServiceStatus.NotFound)
+            return StatusCode((int)HttpStatusCode.NotFound, command);
+
+        return BadRequest(result.Messages);
+    }
+
+    [Obsolete("This method is deprecated. Use DeleteAsync instead.")]
+    protected Task<IActionResult> Delete<TCommand>(TCommand command)
+        where TCommand : class, ICommand
+        => DeleteAsync<TCommand>(command);
+
+    protected async Task<IActionResult> DeleteAsync<TCommand>(TCommand command)
+        where TCommand : class, ICommand
+    {
+        var result = await CommandDispatcher.Send(command);
+        if (result.Status is ApplicationServiceStatus.Ok)
+            return StatusCode((int)HttpStatusCode.OK);
+
+        if (result.Status is ApplicationServiceStatus.NotFound)
+            return StatusCode((int)HttpStatusCode.NotFound, command);
+
+        return BadRequest(result.Messages);
+    }
+
+    [Obsolete("This method is deprecated. Use QueryAsync instead.")]
+    protected Task<IActionResult> Query<TQuery, TQueryResult>(TQuery query)
+        where TQuery : class, IQuery<TQueryResult>
+        => QueryAsync<TQuery, TQueryResult>(query);
+
+    protected async Task<IActionResult> QueryAsync<TQuery, TQueryResult>(TQuery query)
+        where TQuery : class, IQuery<TQueryResult>
+    {
+        var result = await QueryDispatcher.Execute<TQuery, TQueryResult>(query);
+
+        if (result.Status.Equals(ApplicationServiceStatus.InvalidDomainState) ||
+            result.Status.Equals(ApplicationServiceStatus.ValidationError))
             return BadRequest(result.Messages);
-        }
 
-        protected async Task<IActionResult> Create<TCommand>(TCommand command) where TCommand : class, ICommand
-        {
-            var result = await CommandDispatcher.Send(command);
-            if (result.Status == ApplicationServiceStatus.Ok)
-            {
-                return StatusCode((int)HttpStatusCode.Created);
-            }
-            return BadRequest(result.Messages);
-        }
+        if (result.Status.Equals(ApplicationServiceStatus.NotFound) || result.Data == null)
+            return StatusCode((int)HttpStatusCode.NoContent);
 
+        if (result.Status.Equals(ApplicationServiceStatus.Ok))
+            return Ok(result.Data);
 
-        protected async Task<IActionResult> Edit<TCommand, TCommandResult>(TCommand command) where TCommand : class, ICommand<TCommandResult>
-        {
-            var result = await CommandDispatcher.Send<TCommand, TCommandResult>(command);
-            if (result.Status == ApplicationServiceStatus.Ok)
-            {
-                return StatusCode((int)HttpStatusCode.OK, result.Data);
-            }
-            else if (result.Status == ApplicationServiceStatus.NotFound)
-            {
-                return StatusCode((int)HttpStatusCode.NotFound, command);
-            }
-            return BadRequest(result.Messages);
-        }
-
-        protected async Task<IActionResult> Edit<TCommand>(TCommand command) where TCommand : class, ICommand
-        {
-            var result = await CommandDispatcher.Send(command);
-            if (result.Status == ApplicationServiceStatus.Ok)
-            {
-                return StatusCode((int)HttpStatusCode.OK);
-            }
-            else if (result.Status == ApplicationServiceStatus.NotFound)
-            {
-                return StatusCode((int)HttpStatusCode.NotFound, command);
-            }
-            return BadRequest(result.Messages);
-        }
-
-
-        protected async Task<IActionResult> Delete<TCommand, TCommandResult>(TCommand command) where TCommand : class, ICommand<TCommandResult>
-        {
-            var result = await CommandDispatcher.Send<TCommand, TCommandResult>(command);
-            if (result.Status == ApplicationServiceStatus.Ok)
-            {
-                return StatusCode((int)HttpStatusCode.OK, result.Data);
-            }
-            else if (result.Status == ApplicationServiceStatus.NotFound)
-            {
-                return StatusCode((int)HttpStatusCode.NotFound, command);
-            }
-            return BadRequest(result.Messages);
-        }
-
-        protected async Task<IActionResult> Delete<TCommand>(TCommand command) where TCommand : class, ICommand
-        {
-            var result = await CommandDispatcher.Send(command);
-            if (result.Status == ApplicationServiceStatus.Ok)
-            {
-                return StatusCode((int)HttpStatusCode.OK);
-            }
-            else if (result.Status == ApplicationServiceStatus.NotFound)
-            {
-                return StatusCode((int)HttpStatusCode.NotFound, command);
-            }
-            return BadRequest(result.Messages);
-        }
-
-
-        protected async Task<IActionResult> Query<TQuery, TQueryResult>(TQuery query) where TQuery : class, IQuery<TQueryResult>
-        {
-            var result = await QueryDispatcher.Execute<TQuery, TQueryResult>(query);
-
-            if (result.Status.Equals(ApplicationServiceStatus.InvalidDomainState) || result.Status.Equals(ApplicationServiceStatus.ValidationError))
-            {
-                return BadRequest(result.Messages);
-            }
-            else if (result.Status.Equals(ApplicationServiceStatus.NotFound) || result.Data == null)
-            {
-                return StatusCode((int)HttpStatusCode.NoContent);
-            }
-            else if (result.Status.Equals(ApplicationServiceStatus.Ok))
-            {
-                return Ok(result.Data);
-            }
-
-            return BadRequest(result.Messages);
-        }
+        return BadRequest(result.Messages);
     }
 }


### PR DESCRIPTION
The name of the async methods was modified to make the code readable.
There are methods with the previous name and they just became obsolete.